### PR TITLE
Make EC payment properly support IPN packets.

### DIFF
--- a/paypal_payment_ec/includes/PayPalPaymentECPaymentMethodController.inc
+++ b/paypal_payment_ec/includes/PayPalPaymentECPaymentMethodController.inc
@@ -7,7 +7,7 @@
 /**
  * A PayPal Express Checkout payment method.
  */
-class PayPalPaymentECPaymentMethodController extends PayPalPaymentNVPAPIPaymentMethodControllerBase {
+class PayPalPaymentECPaymentMethodController extends PayPalPaymentNVPAPIPaymentMethodControllerBase implements PayPalPaymentIPNPaymentMethodControllerInterface {
 
   /**
    * Automatic funds capture.
@@ -345,6 +345,22 @@ class PayPalPaymentECPaymentMethodController extends PayPalPaymentNVPAPIPaymentM
       } 
     }
     return PAYMENT_STATUS_UNKNOWN;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function PayPalValidateIPNVariables(Payment $payment, array $ipn_variables) {
+    // PayPal treats email addresses case-insensitively and returns them in
+    // lowercase in $ipn_variables['business']. Therefore we must perform
+    // a case-insensitive comparison.
+    return strtolower($ipn_variables['business']) == strtolower($payment->method->controller_data['email_address']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function PayPalProcessIPN(Payment $payment, array $ipn_variables) {
   }
 
 }


### PR DESCRIPTION
Several places in `paypal_payment_ipn` use the interface to check whether they should be active. Both EC and PPS use IPN so both should implement that interface.