### PR TITLE
EC/IPN: Allow payment methods without email address.

### DIFF
--- a/paypal_payment_ec/includes/PayPalPaymentECPaymentMethodController.inc
+++ b/paypal_payment_ec/includes/PayPalPaymentECPaymentMethodController.inc
@@ -351,10 +351,7 @@ class PayPalPaymentECPaymentMethodController extends PayPalPaymentNVPAPIPaymentM
    * {@inheritdoc}
    */
   public static function PayPalValidateIPNVariables(Payment $payment, array $ipn_variables) {
-    // PayPal treats email addresses case-insensitively and returns them in
-    // lowercase in $ipn_variables['business']. Therefore we must perform
-    // a case-insensitive comparison.
-    return strtolower($ipn_variables['business']) == strtolower($payment->method->controller_data['email_address']);
+    return TRUE;
   }
 
   /**


### PR DESCRIPTION
The express checkout payment method doesn’t require an email address. So we shouldn’t check whether it matches the address of the `$ipn['business']`. Integrity of the IPN package is secured by a signature.